### PR TITLE
Dunders in init script

### DIFF
--- a/webweb/__init__.py
+++ b/webweb/__init__.py
@@ -1,3 +1,6 @@
 name = "webweb"
 
+__version__ = '0.0.37'
+__authors__ = 'Daniel Larremore; Hunter Wapman'
+
 from .webweb import Web

--- a/webweb/webweb.py
+++ b/webweb/webweb.py
@@ -7,8 +7,6 @@
 # daniel.larremore@colorado.edu
 # http://github.com/dblarremore/webweb Comments and suggestions always welcome.
 
-__version__ = '0.0.37'
-__authors__ = 'Daniel Larremore; Hunter Wapman'
 
 import copy
 import json


### PR DESCRIPTION
So that they are accessible from the module as `webweb.__version__` instead of at the file level as `webweb.webweb.__version___`.